### PR TITLE
Sanitize sensitive settings

### DIFF
--- a/labmunkznetwork/settings.py
+++ b/labmunkznetwork/settings.py
@@ -14,6 +14,9 @@ from pathlib import Path
 import os
 import environ
 
+env = environ.Env()
+environ.Env.read_env()
+
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 #BASE_DIR = Path(__file__).resolve().parent.parent
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -21,12 +24,12 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/3.2/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'django-insecure-&6=puxxn_1x^8ob2$t@(@7avuihy(@ri8set=fx8_c_^qma&6-'
+SECRET_KEY = env('SECRET_KEY')
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = env.bool('DEBUG', default=False)
 
-ALLOWED_HOSTS = ['.labmunkzink.com', 'www.labmunkzink.com', '.labmunkz.com', 'www.labmunkz.com', 'labmunkzart.com', 'www.labmunkzart.com', '104.248.214.235', 'localhost', 'www.jivinscientists.com', '.jivinscientists.com', 'jivinscientists.com',]
+ALLOWED_HOSTS = env.list('ALLOWED_HOSTS', default=['localhost'])
 
 AUTH_USER_MODEL = 'munkz.ArtistProfile'
 
@@ -108,11 +111,11 @@ WSGI_APPLICATION = 'labmunkznetwork.wsgi.application'
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql_psycopg2',
-        'NAME': 'labmunkzink',
-        'USER': 'labmunk',
-        'PASSWORD': 'L0vat0L0ve',
-        'HOST': 'localhost',
-        'PORT': '5432',
+        'NAME': env('DB_NAME', default='labmunkzink'),
+        'USER': env('DB_USER', default='labmunk'),
+        'PASSWORD': env('DB_PASSWORD', default=''),
+        'HOST': env('DB_HOST', default='localhost'),
+        'PORT': env('DB_PORT', default='5432'),
     }
 }
 
@@ -163,14 +166,11 @@ FILE_UPLOAD_MAX_MEMORY_SIZE = 20 * 1024 * 1024  # 20MB
 LOGIN_REDIRECT_URL = '/'
 LOGOUT_REDIRECT_URL = '/'
 
-env = environ.Env()
-environ.Env.read_env()
-
-#EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
-#EMAIL_HOST = 'smtp.gmail.com'
-#EMAIL_PORT = 587
-#EMAIL_USE_TLS = True
-#MAIL_USE_SSL = False
-#EMAIL_HOST_USER = 'letsreaddad@gmail.com'
-#EMAIL_HOST_PASSWORD = 'hrjq hjrp nwtx qfud'
-#DEFAULT_FROM_EMAIL = 'letsreaddad@gmail.com'
+# Email configuration loaded from environment variables
+EMAIL_BACKEND = env('EMAIL_BACKEND', default='django.core.mail.backends.smtp.EmailBackend')
+EMAIL_HOST = env('EMAIL_HOST', default='smtp.gmail.com')
+EMAIL_PORT = env.int('EMAIL_PORT', default=587)
+EMAIL_USE_TLS = env.bool('EMAIL_USE_TLS', default=True)
+EMAIL_HOST_USER = env('EMAIL_HOST_USER', default='')
+EMAIL_HOST_PASSWORD = env('EMAIL_HOST_PASSWORD', default='')
+DEFAULT_FROM_EMAIL = env('DEFAULT_FROM_EMAIL', default='')


### PR DESCRIPTION
## Summary
- load `SECRET_KEY`, `DEBUG`, and `ALLOWED_HOSTS` from environment variables
- read database configuration from environment variables
- configure email settings from environment variables

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6869efa379cc83328f79b571a7231eaa