### PR TITLE
Ignore project settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,9 @@ coverage.xml
 # Django stuff:
 *.log
 local_settings.py
+labmunkznetwork/settings.py
+schedule/settings.py
+setting.py
 
 # Flask stuff:
 instance/


### PR DESCRIPTION
## Summary
- ignore project setting files in Git

## Testing
- `python manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_686af2d41cd88332af6a8ac6241d2f94