### PR TITLE
Fix missing easter egg view

### DIFF
--- a/home/views.py
+++ b/home/views.py
@@ -79,3 +79,7 @@ def unsubscribe(request, email):
     except Subscriber.DoesNotExist:
         messages.error(request, "Email not found.")
     return redirect('home:home')
+
+def easter_egg(request):
+    """Render the playful easter egg page."""
+    return render(request, "home/easter_egg.html")


### PR DESCRIPTION
## Summary
- add `easter_egg` view for the secret lab URL

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686aff1c49f883329c9c3902834a0c73