### PR TITLE
Fix calendar slug in group detail

### DIFF
--- a/group/templates/group_detail.html
+++ b/group/templates/group_detail.html
@@ -132,7 +132,7 @@
         <!-- Events Section -->
         <div id="events" class="tab-content">
             <h2>Upcoming Events</h2>
-            <iframe src="/schedule/calendar/compact_month/{{ group_detail.group_name|lower }}" class="mini-calendar"></iframe>
+            <iframe src="/schedule/calendar/compact_month/{{ group_detail.group_name|slugify }}" class="mini-calendar"></iframe>
             <p class="event-note">If no events appear, please check back soon!</p>
         </div>
 


### PR DESCRIPTION
## Summary
- ensure calendar URLs use slugified group names

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686b13d89ac0833287468dc10fb69525