### PR TITLE
Fix nested anchor tags in group detail member list

### DIFF
--- a/group/templates/group_detail.html
+++ b/group/templates/group_detail.html
@@ -110,9 +110,9 @@
                                 {% endif %}
                                 <td>
                                 <div class="album-card">
-                                    <a style="color:black;font-weight:bold;" href="{% url 'munkz:artist-detail' member.pk %}">
-                                    <a href="{% url 'munkz:artist-detail' member.pk %}">{{ member.get_full_name }}</a>
-                                    </a> 
+                                    <a href="{% url 'munkz:artist-detail' member.pk %}" style="color:black;font-weight:bold;">
+                                        {{ member.get_full_name }}
+                                    </a>
                                 </div>
                                 </td>
                             </tr>


### PR DESCRIPTION
## Summary
- remove nested `<a>` elements in `group_detail.html`
- clean up member list links

## Testing
- `python manage.py test` *(fails: Django not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686b1c46145083329c63315d619f1a43