### PR TITLE
Fix missing logo file handling in group detail

### DIFF
--- a/group/templates/group_detail.html
+++ b/group/templates/group_detail.html
@@ -15,9 +15,13 @@
 <div class="container">
     <div class="card">
         <!-- Group Banner -->
-        <div class="profile-banner" style="background-image: url('{{ group_detail.logo.url }}');">
+        <div class="profile-banner" {% if group_detail.logo %}style="background-image: url('{{ group_detail.logo.url }}');"{% endif %}>
             <div class="profile-pic-container">
-                <img src="{{ group_detail.button.url }}" alt="{{ group_detail.group_name }} Logo" loading="lazy">
+                {% if group_detail.button %}
+                    <img src="{{ group_detail.button.url }}" alt="{{ group_detail.group_name }} Logo" loading="lazy">
+                {% else %}
+                    <img src="{% static '/home/images/LMNlogo.jpg' %}" alt="{{ group_detail.group_name }} Logo" loading="lazy">
+                {% endif %}
             </div>
         </div>
 


### PR DESCRIPTION
## Summary
- avoid raising ValueError when a group has no uploaded logo or button

## Testing
- `python3 manage.py test` *(fails: Could not import Django)*

------
https://chatgpt.com/codex/tasks/task_e_686b1fd3f69c8332b31a809cbf233ac6