### PR TITLE
Fix mobile stacking for album detail

### DIFF
--- a/static/home/css/styles.css
+++ b/static/home/css/styles.css
@@ -347,7 +347,12 @@ main {
     .container-home {
         display: inline-block;
     }
-}    
+
+    /* Stack music cards vertically on small screens */
+    .container-music {
+        grid-template-columns: 1fr;
+    }
+}
 
 .card {
     flex: 1;


### PR DESCRIPTION
## Summary
- update responsive CSS for album detail layout so business-card elements stack vertically on small screens

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686b245539c483329ede24aa88ec400f