### PR TITLE
Fix group detail calendar and member listing

### DIFF
--- a/group/templates/group_detail.html
+++ b/group/templates/group_detail.html
@@ -139,7 +139,7 @@
         <!-- Events Section -->
         <div id="events" class="tab-content">
             <h2>Upcoming Events</h2>
-            <iframe src="{% url 'schedule:compact_calendar' group_detail.group_name|slugify %}" class="mini-calendar"></iframe>
+            <iframe src="{% url 'schedule:compact_calendar' calendar.slug %}" class="mini-calendar"></iframe>
             <p class="event-note">If no events appear, please check back soon!</p>
         </div>
 

--- a/group/views.py
+++ b/group/views.py
@@ -5,6 +5,7 @@ from django.urls import reverse_lazy
 from .models import Group, Album
 from munkz.models import ArtistProfile
 from music.models import AudioFile
+from schedule.models import Calendar
 #from client.models import Client
 
 def group(request):
@@ -19,18 +20,22 @@ def group(request):
     
 def GroupDeView(request, id):
     template_name = 'group_detail.html'
-    group_detail = Group.objects.get(id=id) 
+    group_detail = Group.objects.get(id=id)
     group_album_list = Album.objects.all().filter(group__id=group_detail.pk)
     group_member_list = ArtistProfile.objects.all().filter(group__id=group_detail.pk)
-    
+    calendar = Calendar.objects.get_or_create_calendar_for_object(
+        group_detail, name=f"{group_detail.group_name} Calendar"
+    )
+
     return render(
         request,
         template_name,
         context={
             'group_detail':group_detail,
             'group_album_list':group_album_list,
-            'group_member_list':group_member_list
-             }, 
+            'group_member_list':group_member_list,
+            'calendar': calendar,
+             },
     )
 
 class GroupListView(generic.ListView):


### PR DESCRIPTION
## Summary
- create or fetch a calendar for the current group in `GroupDeView`
- pass calendar to template and use its slug for the embedded compact calendar iframe

## Testing
- `python -m py_compile group/views.py`


------
https://chatgpt.com/codex/tasks/task_e_686b25cb878083329a4aeda1e0c6733a