### PR TITLE
Update group detail layout

### DIFF
--- a/group/templates/group_detail.html
+++ b/group/templates/group_detail.html
@@ -39,15 +39,8 @@
             <p class="group-summary">{{ group_detail.summary }}</p>
         </div>
 
-        <!-- Tabs for Sections -->
-        <div class="group-tabs">
-            <button class="tab-link active" onclick="openTab(event, 'albums')">🎵 Albums</button>
-            <button class="tab-link" onclick="openTab(event, 'members')">👥 Members</button>
-            <button class="tab-link" onclick="openTab(event, 'events')">🎤 Events</button>
-        </div>
-
-        <!-- Albums Section -->
-        <div id="albums" class="tab-content active">
+        <!-- Albums -->
+        <div id="albums" class="tab-content">
             <div class="business-card">
                 <h2>Albums</h2>
                 <table width="100%" cellspacing="0" style="border-radius: 8%;">
@@ -136,11 +129,23 @@
             </div>
         </div>
 
-        <!-- Events Section -->
+        <!-- Events -->
         <div id="events" class="tab-content">
             <h2>Upcoming Events</h2>
-            <iframe src="{% url 'schedule:compact_calendar' calendar.slug %}" class="mini-calendar"></iframe>
-            <p class="event-note">If no events appear, please check back soon!</p>
+            <table width="100%" cellspacing="0" style="border-radius: 8%;">
+                <tbody>
+                    {% for event in upcoming_events %}
+                    <tr>
+                        <td style="width: 150px;">{{ event.start|date:"M d, Y" }}</td>
+                        <td>{{ event.title }}</td>
+                    </tr>
+                    {% empty %}
+                    <tr>
+                        <td colspan="2" class="event-note">No upcoming events.</td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
         </div>
 
         <!-- Contact Info -->
@@ -160,19 +165,4 @@
     </div>
 </div>
 
-<script>
-    function openTab(evt, tabName) {
-        var i, tabcontent, tablinks;
-        tabcontent = document.getElementsByClassName("tab-content");
-        for (i = 0; i < tabcontent.length; i++) {
-            tabcontent[i].style.display = "none";
-        }
-        tablinks = document.getElementsByClassName("tab-link");
-        for (i = 0; i < tablinks.length; i++) {
-            tablinks[i].classList.remove("active");
-        }
-        document.getElementById(tabName).style.display = "block";
-        evt.currentTarget.classList.add("active");
-    }
-</script>
 {% endblock %}

--- a/group/views.py
+++ b/group/views.py
@@ -5,6 +5,8 @@ from django.urls import reverse_lazy
 from .models import Group, Album
 from munkz.models import ArtistProfile
 from music.models import AudioFile
+# from django.utils import timezone for filtering events
+from django.utils import timezone
 from schedule.models import Calendar
 #from client.models import Client
 
@@ -26,6 +28,7 @@ def GroupDeView(request, id):
     calendar = Calendar.objects.get_or_create_calendar_for_object(
         group_detail, name=f"{group_detail.group_name} Calendar"
     )
+    upcoming_events = calendar.events.filter(start__gte=timezone.now()).order_by('start')
 
     return render(
         request,
@@ -35,6 +38,7 @@ def GroupDeView(request, id):
             'group_album_list':group_album_list,
             'group_member_list':group_member_list,
             'calendar': calendar,
+            'upcoming_events': upcoming_events,
              },
     )
 

--- a/static/group/css/group_detail.css
+++ b/static/group/css/group_detail.css
@@ -51,24 +51,20 @@
 }
 
 /* Tabs */
+/* Tabs */
 .group-tabs {
-    margin-top: 20px;
+    display: none;
 }
 .tab-link {
-    background: #eee;
-    border: none;
-    padding: 10px 20px;
-    cursor: pointer;
-    margin: 5px;
+    display: none;
 }
 .tab-link.active {
-    background: #333;
-    color: white;
+    display: none;
 }
 
 /* Tab Content */
 .tab-content {
-    display: none;
+    display: block;
     padding: 20px;
     background: #f8f8f8;
     border-radius: 5px;


### PR DESCRIPTION
## Summary
- get upcoming events in `GroupDeView`
- remove tabs and iframe in group detail page
- always show event list without JavaScript
- hide tab CSS and show sections by default

## Testing
- `python manage.py test` *(fails: Django not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686b28c2e7bc83328f1fdc88452bad8e