### PR TITLE
Improve group event list

### DIFF
--- a/group/templates/group_detail.html
+++ b/group/templates/group_detail.html
@@ -132,16 +132,26 @@
         <!-- Events -->
         <div id="events" class="tab-content">
             <h2>Upcoming Events</h2>
-            <table width="100%" cellspacing="0" style="border-radius: 8%;">
+            <table class="tour-table" width="100%" cellspacing="0" style="border-radius: 8%;">
+                <thead>
+                    <tr>
+                        <th>Date</th>
+                        <th>Event</th>
+                        <th>City</th>
+                        <th>State</th>
+                    </tr>
+                </thead>
                 <tbody>
                     {% for event in upcoming_events %}
                     <tr>
                         <td style="width: 150px;">{{ event.start|date:"M d, Y" }}</td>
-                        <td>{{ event.title }}</td>
+                        <td><a href="{{ event.get_absolute_url }}">{{ event.title }}</a></td>
+                        <td>{{ event.project.jobsite.city|default:'' }}</td>
+                        <td>{{ event.project.jobsite.state|default:'' }}</td>
                     </tr>
                     {% empty %}
                     <tr>
-                        <td colspan="2" class="event-note">No upcoming events.</td>
+                        <td colspan="4" class="event-note">No upcoming events.</td>
                     </tr>
                     {% endfor %}
                 </tbody>

--- a/static/group/css/group_detail.css
+++ b/static/group/css/group_detail.css
@@ -93,8 +93,29 @@
     .group-name {
         font-size: 22px;
     }
-    .tab-link {
-        padding: 8px;
-        font-size: 14px;
-    }
+.tab-link {
+    padding: 8px;
+    font-size: 14px;
+}
+}
+
+/* Tour Table */
+.tour-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 10px;
+}
+
+.tour-table th,
+.tour-table td {
+    padding: 8px;
+    border-bottom: 1px solid #ddd;
+}
+
+.tour-table th {
+    text-align: left;
+}
+
+.tour-table tr:nth-child(even) {
+    background-color: #f2f2f2;
 }


### PR DESCRIPTION
## Summary
- make upcoming events render like a tour list
- add basic styling for the new table

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686b304b0b7883328f069d0a06abe822