### PR TITLE
Fix event URL resolution

### DIFF
--- a/schedule/models/events.py
+++ b/schedule/models/events.py
@@ -124,7 +124,7 @@ class Event(models.Model):
         return float(self.seconds) / 3600
 
     def get_absolute_url(self):
-        return reverse('event', args=[self.id])
+        return reverse('schedule:event', args=[self.id])
 
     def get_occurrences(self, start, end, clear_prefetch=True):
         """


### PR DESCRIPTION
## Summary
- fix `get_absolute_url` for Event model

## Testing
- `python manage.py test` *(fails: ImportError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686b3240e1c483329117acd338af0dd0