### PR TITLE
Fix day_calendar url resolution

### DIFF
--- a/schedule/models/calendars.py
+++ b/schedule/models/calendars.py
@@ -175,8 +175,8 @@ class Calendar(models.Model):
 
     def get_absolute_url(self):
         if USE_FULLCALENDAR:
-            return reverse('fullcalendar', kwargs={'calendar_slug': self.slug})
-        return reverse('calendar_home', kwargs={'calendar_slug': self.slug})
+            return reverse('schedule:fullcalendar', kwargs={'calendar_slug': self.slug})
+        return reverse('schedule:calendar_home', kwargs={'calendar_slug': self.slug})
 
 
 class CalendarRelationManager(models.Manager):

--- a/schedule/templates/schedule/_day_cell.html
+++ b/schedule/templates/schedule/_day_cell.html
@@ -8,7 +8,7 @@
     <td style="color:blue;">
   {% endif %}
   
-  <a style="color:#000;" href="{% url 'day_calendar' calendar.slug %}{% querystring_for_date day.start 3 %}">
+  <a style="color:#000;" href="{% url 'schedule:day_calendar' calendar.slug %}{% querystring_for_date day.start 3 %}">
   <div style="text-align: center;height:100%;width:100%;">
     <strong>{{day.start.day}}</strong>
   </div>

--- a/schedule/templates/schedule/calendar.html
+++ b/schedule/templates/schedule/calendar.html
@@ -18,7 +18,7 @@
         <li><a href="{% url "tri_month_calendar" calendar.slug %}">{% trans "3 Months" %}</a></li>
         <li><a href="{% url "year_calendar" calendar.slug %}">{% trans "This Year" %}</a></li>
         <li><a href="{% url "week_calendar" calendar.slug %}">{% trans "Weekly" %}</a></li>
-        <li><a href="{% url "day_calendar" calendar.slug %}">{% trans "Daily" %}</a></li>
+        <li><a href="{% url "schedule:day_calendar" calendar.slug %}">{% trans "Daily" %}</a></li>
     </ul>
 </div>
 

--- a/schedule/templates/schedule/calendar_day.html
+++ b/schedule/templates/schedule/calendar_day.html
@@ -10,7 +10,7 @@
 {% include "schedule/_dialogs.html" %}
 <div class="row row-centered">
  <div class="col">
-    <a class="btn btn-primary gradient" href="{% url "day_calendar" calendar.slug %}">
+    <a class="btn btn-primary gradient" href="{% url "schedule:day_calendar" calendar.slug %}">
       {% trans "Today" %}
     </a>
   <a class="btn btn-primary gradient" href="{% url "week_calendar" calendar.slug %}{% querystring_for_date period.start 3 %}">
@@ -18,7 +18,7 @@
   </a>
  </div>
  <div class="col">
-  {% prevnext "day_calendar" calendar period "l, F d, Y" %}
+  {% prevnext "schedule:day_calendar" calendar period "l, F d, Y" %}
  </div>
  <div class="col">
   <div style="float: right;">

--- a/schedule/templates/schedule/calendar_list.html
+++ b/schedule/templates/schedule/calendar_list.html
@@ -11,7 +11,7 @@
   <a href="{% url "tri_month_calendar" cal.slug %}">{% trans "3 Months" %}</a> --
   <a href="{% url "year_calendar" cal.slug %}">{% trans "This Year" %}</a> --
   <a href="{% url "week_calendar" cal.slug %}">{% trans "Weekly" %}</a> --
-  <a href="{% url "day_calendar" cal.slug %}">{% trans "Daily" %}</a></li><br>
+  <a href="{% url "schedule:day_calendar" cal.slug %}">{% trans "Daily" %}</a></li><br>
 {% endfor %}
 </ul>
 {% endblock %}

--- a/schedule/templates/schedule/calendar_month.html
+++ b/schedule/templates/schedule/calendar_month.html
@@ -23,7 +23,7 @@
    <div class="card sched_container scheduler_month">
    <div class="row sched_navline" style="width: 100%;">
     <div class="col">
-      <a href="{% url "day_calendar" calendar.slug %}"><div class="btn-custom sched_tab sched_tab_first" name="day_tab">{% trans "Day" %}</div></a>
+      <a href="{% url "schedule:day_calendar" calendar.slug %}"><div class="btn-custom sched_tab sched_tab_first" name="day_tab">{% trans "Day" %}</div></a>
       <a href="{% url "week_calendar" calendar.slug %}"><div class="btn-custom sched_tab" name="week_tab">{% trans "Week" %}</div></a>
       <a href="{% url "month_calendar" calendar.slug %}{% querystring_for_date period.start 2 %}"><div class="btn-custom sched_tab active" name="month_tab">{% trans "Month" %}</div></a>
       <a href="{% url "year_calendar" calendar.slug %}{% querystring_for_date period.start 1 %}"><div class="btn-custom sched_tab sched_tab_last" name="month_tab">{% trans "Year" %}</div></a>

--- a/schedule/templates/schedule/calendar_week.html
+++ b/schedule/templates/schedule/calendar_week.html
@@ -31,7 +31,7 @@
   {% for day in period.get_days %}
     <div class="col-md-3">
       <div class="row row-centered">
-        <a class="btn btn-primary gradient" href="{% url "day_calendar" calendar.slug %}{% querystring_for_date day.start 3 %}">
+        <a class="btn btn-primary gradient" href="{% url "schedule:day_calendar" calendar.slug %}{% querystring_for_date day.start 3 %}">
           {{day.start|date:"l, d"}}
         </a>
       </div>

--- a/schedule/templates/schedule/event.html
+++ b/schedule/templates/schedule/event.html
@@ -123,7 +123,7 @@
         </div>
       </div>
     <div class="col-lg-6">
-      <a class="btn btn-primary gradient" href="{% url "day_calendar" event.calendar.slug %}{% querystring_for_date event.start 3 %}">
+      <a class="btn btn-primary gradient" href="{% url "schedule:day_calendar" event.calendar.slug %}{% querystring_for_date event.start 3 %}">
         {% trans "Day" %}
       </a>
       <a class="btn btn-primary gradient" href="{% url "month_calendar" event.calendar.slug %}{% querystring_for_date event.start 2 %}">

--- a/schedule/templates/schedule/occurrence.html
+++ b/schedule/templates/schedule/occurrence.html
@@ -3,7 +3,7 @@
 
 {% block body %}
 <div class="navigation">
-  <a class="btn btn-primary gradient" href="{% url "day_calendar" occurrence.event.calendar.slug %}{% querystring_for_date occurrence.start 3 %}">
+  <a class="btn btn-primary gradient" href="{% url "schedule:day_calendar" occurrence.event.calendar.slug %}{% querystring_for_date occurrence.start 3 %}">
     {% trans "Day" %}
   </a>
   <a class="btn btn-primary gradient" href="{% url "month_calendar" occurrence.event.calendar.slug %}{% querystring_for_date occurrence.start 2 %}">

--- a/schedule/templates/schedule/schedule_day_list.html
+++ b/schedule/templates/schedule/schedule_day_list.html
@@ -9,7 +9,7 @@
 
 {% block content %}
   <div class="col-lg-6">
-    <a class="btn btn-primary gradient" href="{% url "day_calendar" event.calendar.slug %}{% querystring_for_date event.start 3 %}">
+    <a class="btn btn-primary gradient" href="{% url "schedule:day_calendar" event.calendar.slug %}{% querystring_for_date event.start 3 %}">
       {% trans "Day" %}
     </a>
     <a class="btn btn-primary gradient" href="{% url "month_calendar" event.calendar.slug %}{% querystring_for_date event.start 2 %}">

--- a/schedule/views.py
+++ b/schedule/views.py
@@ -279,7 +279,7 @@ class DeleteEventView(EventEditMixin, DeleteView):
         # If the key word argument redirect is set
         # Lastly redirect to the event detail of the recently create event
         """
-        url_val = 'fullcalendar' if USE_FULLCALENDAR else 'day_calendar'
+        url_val = 'schedule:fullcalendar' if USE_FULLCALENDAR else 'schedule:day_calendar'
         next_url = self.kwargs.get('next') or reverse(url_val, args=[self.object.calendar.slug])
         next_url = get_next_url(self.request, next_url)
         return next_url


### PR DESCRIPTION
## Summary
- use namespaced url names for day calendars
- update redirects to use new namespaced routes

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686b333ff21083328fed77a9c4209991