### PR TITLE
Fix schedule templates to use app namespace

### DIFF
--- a/schedule/templates/schedule/_month_table.html
+++ b/schedule/templates/schedule/_month_table.html
@@ -12,7 +12,7 @@
   {% for week in month.get_weeks %}
       <tr>
       <td style="width:4%;" class="calendr-day">
-          <a href="{% url "week_calendar" calendar.slug %}{% querystring_for_date week.start 3 %}">
+          <a href="{% url "schedule:week_calendar" calendar.slug %}{% querystring_for_date week.start 3 %}">
               <i class="fa fa-calendar-plus-o" aria-hidden="true"></i>
           </a>
       </td>

--- a/schedule/templates/schedule/calendar.html
+++ b/schedule/templates/schedule/calendar.html
@@ -13,11 +13,11 @@
 <div>
     <p>{% trans "See as:" %}</p>
     <ul>
-        <li><a href="{% url "compact_calendar" calendar.slug %}">{% trans "Small Month" %}</a></li>
-        <li><a href="{% url "month_calendar" calendar.slug %}">{% trans "1 Month" %}</a></li>
-        <li><a href="{% url "tri_month_calendar" calendar.slug %}">{% trans "3 Months" %}</a></li>
-        <li><a href="{% url "year_calendar" calendar.slug %}">{% trans "This Year" %}</a></li>
-        <li><a href="{% url "week_calendar" calendar.slug %}">{% trans "Weekly" %}</a></li>
+        <li><a href="{% url "schedule:compact_calendar" calendar.slug %}">{% trans "Small Month" %}</a></li>
+        <li><a href="{% url "schedule:month_calendar" calendar.slug %}">{% trans "1 Month" %}</a></li>
+        <li><a href="{% url "schedule:tri_month_calendar" calendar.slug %}">{% trans "3 Months" %}</a></li>
+        <li><a href="{% url "schedule:year_calendar" calendar.slug %}">{% trans "This Year" %}</a></li>
+        <li><a href="{% url "schedule:week_calendar" calendar.slug %}">{% trans "Weekly" %}</a></li>
         <li><a href="{% url "schedule:day_calendar" calendar.slug %}">{% trans "Daily" %}</a></li>
     </ul>
 </div>

--- a/schedule/templates/schedule/calendar_day.html
+++ b/schedule/templates/schedule/calendar_day.html
@@ -13,7 +13,7 @@
     <a class="btn btn-primary gradient" href="{% url "schedule:day_calendar" calendar.slug %}">
       {% trans "Today" %}
     </a>
-  <a class="btn btn-primary gradient" href="{% url "week_calendar" calendar.slug %}{% querystring_for_date period.start 3 %}">
+  <a class="btn btn-primary gradient" href="{% url "schedule:week_calendar" calendar.slug %}{% querystring_for_date period.start 3 %}">
     {% trans "Week" %}
   </a>
  </div>
@@ -22,10 +22,10 @@
  </div>
  <div class="col">
   <div style="float: right;">
-  <a class="btn btn-primary gradient" href="{% url "month_calendar" calendar.slug %}{% querystring_for_date period.start 2 %}">
+  <a class="btn btn-primary gradient" href="{% url "schedule:month_calendar" calendar.slug %}{% querystring_for_date period.start 2 %}">
     {% trans "Month" %}
   </a>
-  <a class="btn btn-primary gradient" href="{% url "year_calendar" calendar.slug %}{% querystring_for_date period.start 1 %}">
+  <a class="btn btn-primary gradient" href="{% url "schedule:year_calendar" calendar.slug %}{% querystring_for_date period.start 1 %}">
     {% trans "Year" %}
   </a></div>
  </div>

--- a/schedule/templates/schedule/calendar_list.html
+++ b/schedule/templates/schedule/calendar_list.html
@@ -6,11 +6,11 @@
 <ul>
 {% for cal in object_list %}
 <li><b>{{ cal }}</b> :
-  <a href="{% url "compact_calendar" cal.slug %}">{% trans "Small Month" %}</a> --
-  <a href="{% url "month_calendar" cal.slug %}">{% trans "1 Month" %}</a> --
-  <a href="{% url "tri_month_calendar" cal.slug %}">{% trans "3 Months" %}</a> --
-  <a href="{% url "year_calendar" cal.slug %}">{% trans "This Year" %}</a> --
-  <a href="{% url "week_calendar" cal.slug %}">{% trans "Weekly" %}</a> --
+  <a href="{% url "schedule:compact_calendar" cal.slug %}">{% trans "Small Month" %}</a> --
+  <a href="{% url "schedule:month_calendar" cal.slug %}">{% trans "1 Month" %}</a> --
+  <a href="{% url "schedule:tri_month_calendar" cal.slug %}">{% trans "3 Months" %}</a> --
+  <a href="{% url "schedule:year_calendar" cal.slug %}">{% trans "This Year" %}</a> --
+  <a href="{% url "schedule:week_calendar" cal.slug %}">{% trans "Weekly" %}</a> --
   <a href="{% url "schedule:day_calendar" cal.slug %}">{% trans "Daily" %}</a></li><br>
 {% endfor %}
 </ul>

--- a/schedule/templates/schedule/calendar_month.html
+++ b/schedule/templates/schedule/calendar_month.html
@@ -24,11 +24,11 @@
    <div class="row sched_navline" style="width: 100%;">
     <div class="col">
       <a href="{% url "schedule:day_calendar" calendar.slug %}"><div class="btn-custom sched_tab sched_tab_first" name="day_tab">{% trans "Day" %}</div></a>
-      <a href="{% url "week_calendar" calendar.slug %}"><div class="btn-custom sched_tab" name="week_tab">{% trans "Week" %}</div></a>
-      <a href="{% url "month_calendar" calendar.slug %}{% querystring_for_date period.start 2 %}"><div class="btn-custom sched_tab active" name="month_tab">{% trans "Month" %}</div></a>
-      <a href="{% url "year_calendar" calendar.slug %}{% querystring_for_date period.start 1 %}"><div class="btn-custom sched_tab sched_tab_last" name="month_tab">{% trans "Year" %}</div></a>
+      <a href="{% url "schedule:week_calendar" calendar.slug %}"><div class="btn-custom sched_tab" name="week_tab">{% trans "Week" %}</div></a>
+      <a href="{% url "schedule:month_calendar" calendar.slug %}{% querystring_for_date period.start 2 %}"><div class="btn-custom sched_tab active" name="month_tab">{% trans "Month" %}</div></a>
+      <a href="{% url "schedule:year_calendar" calendar.slug %}{% querystring_for_date period.start 1 %}"><div class="btn-custom sched_tab sched_tab_last" name="month_tab">{% trans "Year" %}</div></a>
     </div>
-    <div class="col sched_date"><span class="month_head">{% prevnext "month_calendar" calendar period "F Y"%}</span></div>
+    <div class="col sched_date"><span class="month_head">{% prevnext "schedule:month_calendar" calendar period "F Y"%}</span></div>
     <div class="col sched_date"><span class="month_head"><div class="calendarname">{{ calendar.name }}</div></span></div>
   </div>
  
@@ -39,10 +39,10 @@
         </div>
       </div>
       <div class="row-centered">
-        <a href="{% url "tri_month_calendar" calendar.slug %}{% querystring_for_date period.start 2 %}">
+        <a href="{% url "schedule:tri_month_calendar" calendar.slug %}{% querystring_for_date period.start 2 %}">
           {% trans "Three Month Calendar" %}
         </a>
-        <a href="{% url "year_calendar" calendar.slug %}{% querystring_for_date period.start 1 %}">
+        <a href="{% url "schedule:year_calendar" calendar.slug %}{% querystring_for_date period.start 1 %}">
           {% trans "Full Year Calendar" %}
         </a>
     </div>

--- a/schedule/templates/schedule/calendar_tri_month.html
+++ b/schedule/templates/schedule/calendar_tri_month.html
@@ -5,9 +5,9 @@
 
 {% block content %}
 <div class="tablewrapper">
-  {% prevnext "tri_month_calendar" calendar period "F Y"%}
+  {% prevnext "schedule:tri_month_calendar" calendar period "F Y"%}
   <div class="now">
-    <a href="{% url "tri_month_calendar" calendar.slug %}">
+    <a href="{% url "schedule:tri_month_calendar" calendar.slug %}">
       {% trans "This month" %}
     </a>
   </div>
@@ -22,10 +22,10 @@
 </table>
 </div>
 <div class="navigation">
-  <a href="{% url "month_calendar" calendar.slug %}{% querystring_for_date period.start 2 %}">
+  <a href="{% url "schedule:month_calendar" calendar.slug %}{% querystring_for_date period.start 2 %}">
     {% trans "Monthly Calendar" %}
   </a>
-  <a href="{% url "year_calendar" calendar.slug %}{% querystring_for_date period.start 1 %}">
+  <a href="{% url "schedule:year_calendar" calendar.slug %}{% querystring_for_date period.start 1 %}">
     {% trans "Full Year Calendar" %}
   </a>
 </div>

--- a/schedule/templates/schedule/calendar_week.html
+++ b/schedule/templates/schedule/calendar_week.html
@@ -9,19 +9,19 @@
 
 <div class="row row-centered">
   <div class="col">
-    <a class="btn btn-primary gradient" href="{% url "month_calendar" calendar.slug %}{% querystring_for_date period.start 2 %}">
+    <a class="btn btn-primary gradient" href="{% url "schedule:month_calendar" calendar.slug %}{% querystring_for_date period.start 2 %}">
       {% trans "Month" %}
     </a>
-    <a class="btn btn-primary gradient" href="{% url "year_calendar" calendar.slug %}{% querystring_for_date period.start 1 %}">
+    <a class="btn btn-primary gradient" href="{% url "schedule:year_calendar" calendar.slug %}{% querystring_for_date period.start 1 %}">
       {% trans "Year" %}
     </a>
   </div>
   <div class="col">
-    {{ calendar.name }} {% prevnext "week_calendar" calendar period "\W\e\ek W, M Y" %}
+    {{ calendar.name }} {% prevnext "schedule:week_calendar" calendar period "\W\e\ek W, M Y" %}
   </div>
   <div class="col">
     <div class="now">
-      <a class="btn btn-primary gradient" href="{% url "week_calendar" calendar.slug %}">
+      <a class="btn btn-primary gradient" href="{% url "schedule:week_calendar" calendar.slug %}">
         {% trans "This week" %}
       </a>
     </div>

--- a/schedule/templates/schedule/calendar_year.html
+++ b/schedule/templates/schedule/calendar_year.html
@@ -5,12 +5,12 @@
 
 <div class="tablewrapper">
     <div class="calendarname">{{ calendar.name }}</div>
-    {% prevnext "year_calendar" calendar period "Y" %}
+    {% prevnext "schedule:year_calendar" calendar period "Y" %}
     <div class="content">
       {% for month in period.get_months %}
         <div class="col-md-3" style="margin-bottom:10px;">
           <div class="row row-centered">
-            <button class="btn btn-custom active" href="{% url "month_calendar" calendar.slug %}{% querystring_for_date month.start 2 %}">{{month.name}}</button>
+            <button class="btn btn-custom active" href="{% url "schedule:month_calendar" calendar.slug %}{% querystring_for_date month.start 2 %}">{{month.name}}</button>
           </div>
           <div>
             {% month_table calendar month "small" %}
@@ -19,10 +19,10 @@
       {% endfor %}
     </div>
 <div class="navigation">
-  <a href="{% url "month_calendar" calendar.slug %}">
+  <a href="{% url "schedule:month_calendar" calendar.slug %}">
     {% trans "Current Month Calendar" %}
   </a>
-  <a href="{% url "year_calendar" calendar.slug %}">
+  <a href="{% url "schedule:year_calendar" calendar.slug %}">
     {% trans "Current Year Calendar" %}
   </a>
 </div>

--- a/schedule/templates/schedule/event.html
+++ b/schedule/templates/schedule/event.html
@@ -126,10 +126,10 @@
       <a class="btn btn-primary gradient" href="{% url "schedule:day_calendar" event.calendar.slug %}{% querystring_for_date event.start 3 %}">
         {% trans "Day" %}
       </a>
-      <a class="btn btn-primary gradient" href="{% url "month_calendar" event.calendar.slug %}{% querystring_for_date event.start 2 %}">
+      <a class="btn btn-primary gradient" href="{% url "schedule:month_calendar" event.calendar.slug %}{% querystring_for_date event.start 2 %}">
         {% trans "Month" %}
       </a>
-      <a class="btn btn-primary gradient" href="{% url "year_calendar" event.calendar.slug %}{% querystring_for_date event.start 1 %}">
+      <a class="btn btn-primary gradient" href="{% url "schedule:year_calendar" event.calendar.slug %}{% querystring_for_date event.start 1 %}">
         {% trans "Year" %}
       </a>
     </div>

--- a/schedule/templates/schedule/occurrence.html
+++ b/schedule/templates/schedule/occurrence.html
@@ -6,10 +6,10 @@
   <a class="btn btn-primary gradient" href="{% url "schedule:day_calendar" occurrence.event.calendar.slug %}{% querystring_for_date occurrence.start 3 %}">
     {% trans "Day" %}
   </a>
-  <a class="btn btn-primary gradient" href="{% url "month_calendar" occurrence.event.calendar.slug %}{% querystring_for_date occurrence.start 2 %}">
+  <a class="btn btn-primary gradient" href="{% url "schedule:month_calendar" occurrence.event.calendar.slug %}{% querystring_for_date occurrence.start 2 %}">
     {% trans "Month" %}
   </a>
-  <a class="btn btn-primary gradient" href="{% url "year_calendar" occurrence.event.calendar.slug %}{% querystring_for_date occurrence.start 1 %}">
+  <a class="btn btn-primary gradient" href="{% url "schedule:year_calendar" occurrence.event.calendar.slug %}{% querystring_for_date occurrence.start 1 %}">
     {% trans "Year" %}
   </a>
 </div>

--- a/schedule/templates/schedule/schedule_day_list.html
+++ b/schedule/templates/schedule/schedule_day_list.html
@@ -12,10 +12,10 @@
     <a class="btn btn-primary gradient" href="{% url "schedule:day_calendar" event.calendar.slug %}{% querystring_for_date event.start 3 %}">
       {% trans "Day" %}
     </a>
-    <a class="btn btn-primary gradient" href="{% url "month_calendar" event.calendar.slug %}{% querystring_for_date event.start 2 %}">
+    <a class="btn btn-primary gradient" href="{% url "schedule:month_calendar" event.calendar.slug %}{% querystring_for_date event.start 2 %}">
       {% trans "Month" %}
     </a>
-    <a class="btn btn-primary gradient" href="{% url "year_calendar" event.calendar.slug %}{% querystring_for_date event.start 1 %}">
+    <a class="btn btn-primary gradient" href="{% url "schedule:year_calendar" event.calendar.slug %}{% querystring_for_date event.start 1 %}">
       {% trans "Year" %}
     </a>
   </div>


### PR DESCRIPTION
## Summary
- prefix schedule URLs with `schedule:` namespace

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686b3509f39883328e478fdc8a5a75d2