### PR TITLE
Add past events list to group detail page

### DIFF
--- a/group/templates/group_detail.html
+++ b/group/templates/group_detail.html
@@ -156,6 +156,32 @@
                     {% endfor %}
                 </tbody>
             </table>
+
+            <h2>Past Events</h2>
+            <table class="tour-table" width="100%" cellspacing="0" style="border-radius: 8%;">
+                <thead>
+                    <tr>
+                        <th>Date</th>
+                        <th>Event</th>
+                        <th>City</th>
+                        <th>State</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for event in old_events %}
+                    <tr>
+                        <td style="width: 150px;">{{ event.start|date:"M d, Y" }}</td>
+                        <td><a href="{{ event.get_absolute_url }}">{{ event.title }}</a></td>
+                        <td>{{ event.project.jobsite.city|default:'' }}</td>
+                        <td>{{ event.project.jobsite.state|default:'' }}</td>
+                    </tr>
+                    {% empty %}
+                    <tr>
+                        <td colspan="4" class="event-note">No past events.</td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
         </div>
 
         <!-- Contact Info -->

--- a/group/views.py
+++ b/group/views.py
@@ -29,6 +29,7 @@ def GroupDeView(request, id):
         group_detail, name=f"{group_detail.group_name} Calendar"
     )
     upcoming_events = calendar.events.filter(start__gte=timezone.now()).order_by('start')
+    old_events = calendar.events.filter(start__lt=timezone.now()).order_by('-start')
 
     return render(
         request,
@@ -39,6 +40,7 @@ def GroupDeView(request, id):
             'group_member_list':group_member_list,
             'calendar': calendar,
             'upcoming_events': upcoming_events,
+            'old_events': old_events,
              },
     )
 


### PR DESCRIPTION
## Summary
- show past events on group detail page

## Testing
- `python manage.py test` *(fails: couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_686b374be3ec83328f21a38f9ad69218