### PR TITLE
Fix upload path for group media

### DIFF
--- a/group/models.py
+++ b/group/models.py
@@ -3,11 +3,18 @@ from django.urls import reverse #for the get_absolute_url return
 import os
 
 def upload_to_group_folder(instance, filename):
-    # Normalize the group name to be used as a folder name
-    group_name = instance.group.group_name.replace(' ', '_').lower()
-    # Generate the folder path
-    folder_name = f'{group_name}/'
-    # Return the full path to the file
+    """Return file path for uploads scoped to a group's folder.
+
+    When called from the :class:`Group` model itself ``instance`` will be a
+    ``Group`` object. In that case the group name is stored directly on the
+    instance. For related models (e.g. ``Album``) ``instance`` will have a
+    ``group`` attribute pointing to the ``Group`` object.  Support both
+    scenarios so the same function can be reused across models.
+    """
+
+    group_obj = getattr(instance, "group", None) or instance
+    group_name = group_obj.group_name.replace(" ", "_").lower()
+    folder_name = f"{group_name}/"
     return os.path.join(folder_name, filename)
 
 def upload_to_group_folder_ac(instance, filename):


### PR DESCRIPTION
## Summary
- handle direct `Group` instances when computing upload paths

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686b3b657cf4833295717423e4b5e830