### PR TITLE
Fix worker references

### DIFF
--- a/project/admin.py
+++ b/project/admin.py
@@ -40,8 +40,8 @@ def copy_project(modeladmin, request, queryset):
         for lead in sd.lead.all():
             sd_copy.lead.add(lead)
 
-        for workers in sd.workers.all():
-            sd_copy.workers.add(workers)
+        for artist in sd.artist.all():
+            sd_copy.artist.add(artist)
  
     sd_copy.save()  # (7) save the copy to the database for M2M relations
 

--- a/project/templates/project/project_form.html
+++ b/project/templates/project/project_form.html
@@ -144,10 +144,10 @@
             </select>
           </div>
           <div class="form-row" style="margin-top: 10px;">
-            <label for="id_workers">&nbsp; Workers:</label> {{ form.workers.errors }}
-            <select class="form-control" name="workers" id="id_workers" multiple="">
-              {% for workers in form.workers %}
-                {{ workers }}
+            <label for="id_artist">&nbsp; Artists:</label> {{ form.artist.errors }}
+            <select class="form-control" name="artist" id="id_artist" multiple="">
+              {% for artist in form.artist %}
+                {{ artist }}
               {% endfor %}
             </select>
           </div>

--- a/project/templates/project/project_update_form.html
+++ b/project/templates/project/project_update_form.html
@@ -149,10 +149,10 @@
             </select>
           </div>
           <div class="form-row" style="margin-top: 10px;">
-            <label for="id_workers">&nbsp; Workers:</label> {{ form.workers.errors }}
-            <select class="form-control" name="workers" id="id_workers" multiple="">
-              {% for workers in form.workers %}
-                {{ workers }}
+            <label for="id_artist">&nbsp; Artists:</label> {{ form.artist.errors }}
+            <select class="form-control" name="artist" id="id_artist" multiple="">
+              {% for artist in form.artist %}
+                {{ artist }}
               {% endfor %}
             </select>
           </div>

--- a/project/views.py
+++ b/project/views.py
@@ -96,9 +96,9 @@ def ProjectDeView(request, job_num):
     event_time = 0
     scheduled_cost = 0
     for eventer in scheduling_event_list:
-        workers = eventer.workers.count()
+        workers = eventer.artist.count()
         event_time += workers * eventer.hours
-        for worker in eventer.workers.all():
+        for worker in eventer.artist.all():
             pay = Decimal(worker.hourly) * Decimal(project_detail.burden)
             event_pay = pay * Decimal(eventer.hours)
             scheduled_cost += event_pay
@@ -181,7 +181,7 @@ class ProjectUpdate(UpdateView):
               'projectmanager',
               'foremen',
               'lead',
-              'workers',
+              'artist',
               'burden',
               'markup',
               'estimated_cost',

--- a/schedule/templates/schedule/_detail.html
+++ b/schedule/templates/schedule/_detail.html
@@ -60,17 +60,17 @@
                 </td>
             </tr>
             {% endif %}
-            {% if occurrence.event.workers %}
+            {% if occurrence.event.artist %}
             <tr>
                 <td colspan="2">
-                    <h3>Workers:</h3>
+                    <h3>Artists:</h3>
                     <ul>
-                        {% for workers in occurrence.event.workers.all %}
+                        {% for artist in occurrence.event.artist.all %}
                         <li>
-                            <a style="color:black;font-weight:bold;" href="{{ workers.get_absolute_url }}">
-                            {{ workers.first_name }} {{ workers.last_name }} :</a> 
-                            <a style="color:black;font-weight:bold;" href="tel:{{ workers.phone_number }}">
-                            {{ workers.phone_number }}</a></li>
+                            <a style="color:black;font-weight:bold;" href="{{ artist.get_absolute_url }}">
+                            {{ artist.first_name }} {{ artist.last_name }} :</a>
+                            <a style="color:black;font-weight:bold;" href="tel:{{ artist.phone_number }}">
+                            {{ artist.phone_number }}</a></li>
                         {% if not forloop.last %} {% endif %}
                         {% endfor %}
                     </ul>

--- a/schedule/templates/schedule/create_event.html
+++ b/schedule/templates/schedule/create_event.html
@@ -28,10 +28,10 @@
                   {{ lead }}
                 {% endfor %}</select></div>
             <div class="form-row">
-              <label for="id_workers">&nbsp; Workers:</label>{{ form.workers.errors }}
-              <select class="form-control" name="workers" multiple="" id="id_workers">
-                {% for workers in form.workers %}
-                  {{ workers }}
+              <label for="id_artist">&nbsp; Artists:</label>{{ form.artist.errors }}
+              <select class="form-control" name="artist" multiple="" id="id_artist">
+                {% for artist in form.artist %}
+                  {{ artist }}
                 {% endfor %}</select></div>
             <div class="form-row">
               <label for="id_calendar">&nbsp; Calendar:</label>{{ form.calendar.errors }}

--- a/schedule/templates/schedule/dayevent_detail.html
+++ b/schedule/templates/schedule/dayevent_detail.html
@@ -65,15 +65,15 @@
       </div>
     </div></div>
     <div class="card mb-3">
-      <div class="card-header"><b>Worker</b> - <a href="">details</a></div>
+      <div class="card-header"><b>Artist</b> - <a href="">details</a></div>
         <div class="card-body">
           <ul>
-            {% for workers in dayevent.workers.all %}
+            {% for artist in dayevent.artist.all %}
               <li>
-                <a style="color:black;font-weight:bold;" href="{{ workers.get_absolute_url }}">
-                {{ workers.first_name }} {{ workers.last_name }} :</a> 
-                <a style="color:black;font-weight:bold;" href="tel:{{ workers.phone_number }}">
-                  {{ workers.phone_number }}</a></li>
+                <a style="color:black;font-weight:bold;" href="{{ artist.get_absolute_url }}">
+                {{ artist.first_name }} {{ artist.last_name }} :</a>
+                <a style="color:black;font-weight:bold;" href="tel:{{ artist.phone_number }}">
+                  {{ artist.phone_number }}</a></li>
             {% if not forloop.last %} {% endif %}
             {% endfor %}
           </ul>

--- a/schedule/templates/schedule/edit_occurrence.html
+++ b/schedule/templates/schedule/edit_occurrence.html
@@ -36,10 +36,10 @@
       <div class="card mb-3">
         <div class="card-body">
           <div class="form-group">
-            <div class="form-row"><label for="id_workers">Workers:</label>{{ form.workers.errors }}
-            <select class="form-control" name="workers" multiple="" id="id_workers">
-              {% for workers in form.workers %}
-                {{ workers }}
+            <div class="form-row"><label for="id_artist">Artists:</label>{{ form.artist.errors }}
+            <select class="form-control" name="artist" multiple="" id="id_artist">
+              {% for artist in form.artist %}
+                {{ artist }}
               {% endfor %}</select></div>
           <div class="form-row"><label for="id_project">Project:</label>{{ form.project.errors }}
             <select class="form-control" name="project" required="" id="id_project">

--- a/schedule/templates/schedule/event.html
+++ b/schedule/templates/schedule/event.html
@@ -111,12 +111,12 @@
       <div class="card-header"><b>Scheduled onsite</b></div>
         <div class="card-body">
           <ul>
-            {% for workers in event.workers.all %}
+            {% for artist in event.artist.all %}
               <li>
-                <a style="color:black;font-weight:bold;" href="{{ workers.get_absolute_url }}">
-                {{ workers.first_name }} {{ workers.last_name }} :</a> 
-                <a style="color:black;font-weight:bold;" href="tel:{{ workers.phone_number }}">
-                  {{ workers.phone_number }}</a></li>
+                <a style="color:black;font-weight:bold;" href="{{ artist.get_absolute_url }}">
+                {{ artist.first_name }} {{ artist.last_name }} :</a>
+                <a style="color:black;font-weight:bold;" href="tel:{{ artist.phone_number }}">
+                  {{ artist.phone_number }}</a></li>
             {% if not forloop.last %} {% endif %}
             {% endfor %}
           </ul>

--- a/schedule/templates/schedule/event_archive_day.html
+++ b/schedule/templates/schedule/event_archive_day.html
@@ -49,10 +49,10 @@
     </tfoot>
     <tbody>
       {% for event in object_list %}
-        {% for workers in event.workers.all %}
+        {% for artist in event.artist.all %}
           <tr style="background-color:{{event.color_event}};">
             <td style="min-width:68px;font-weight:bold;"><a style="color:black;font-weight:bold;" href="{{ event.get_absolute_url }}">{{event.start|date:'m/d'}}</a> </td>
-            <td style="min-width:80px;font-weight:bold;"><a style="color:black;font-weight:bold;" href="{{ workers.get_absolute_url }}">{{ workers.first_name }} {{ workers.last_name }}</a><br> </td>
+            <td style="min-width:80px;font-weight:bold;"><a style="color:black;font-weight:bold;" href="{{ artist.get_absolute_url }}">{{ artist.first_name }} {{ artist.last_name }}</a><br> </td>
             <td style="min-width:92px;font-weight:bold;"><a style="color:black;font-weight:bold;" href="{{ event.get_absolute_url }}">{{ event.start_time|date:'f A' }}</a> </td>
             <td style="min-width:92px;font-weight:bold;"><a style="color:black;font-weight:bold;" href="{{ event.get_absolute_url }}">{{ event.start|date:'f A' }}</a> </td>
             <td style="min-width:220px;font-weight:bold;"><a style="color:black;" href="{{ event.project.get_absolute_url }}">{{ event.project.job_name|truncatechars:48 }}</a> </td>

--- a/schedule/templates/schedule/event_form.html
+++ b/schedule/templates/schedule/event_form.html
@@ -29,10 +29,10 @@
                   {{ lead }}
                 {% endfor %}</select></div>
             <div class="form-row">
-              <label for="id_workers">&nbsp; Workers:</label>{{ form.workers.errors }}
-              <select class="form-control" name="workers" multiple="" id="id_workers">
-                {% for workers in form.workers %}
-                  {{ workers }}
+              <label for="id_artist">&nbsp; Artists:</label>{{ form.artist.errors }}
+              <select class="form-control" name="artist" multiple="" id="id_artist">
+                {% for artist in form.artist %}
+                  {{ artist }}
                 {% endfor %}</select></div>
             <div class="form-row">
               <label for="id_calendar">&nbsp; Calendar:</label>{{ form.calendar.errors }}

--- a/schedule/templates/schedule/schedule_day_list.html
+++ b/schedule/templates/schedule/schedule_day_list.html
@@ -46,10 +46,10 @@
     <tbody>
     {% if schedule_day_list %}
       {% for dayevent in schedule_day_list %}
-        {% for workers in dayevent.workers.all %}
+        {% for artist in dayevent.artist.all %}
           <tr style="background-color:{{dayevent.color_event}};">
             <td style="min-width:68px;font-weight:bold;"><a style="color:black;font-weight:bold;" href="{{ dayevent.get_absolute_url }}">{{dayevent.start|date:"m/d"}}</a> </td>
-            <td style="min-width:80px;font-weight:bold;"><a style="color:black;font-weight:bold;" href="{{ workers.get_absolute_url }}">{{ workers.first_name }} {{ workers.last_name }}</a><br> </td>
+            <td style="min-width:80px;font-weight:bold;"><a style="color:black;font-weight:bold;" href="{{ artist.get_absolute_url }}">{{ artist.first_name }} {{ artist.last_name }}</a><br> </td>
             <td style="min-width:92px;font-weight:bold;"><a style="color:black;font-weight:bold;" href="{{ dayevent.get_absolute_url }}">{{ dayevent.start_time|date:"f A" }}</a> </td>
             <td style="min-width:92px;font-weight:bold;"><a style="color:black;font-weight:bold;" href="{{ dayevent.get_absolute_url }}">{{ dayevent.start|date:"f A" }}</a> </td>
             <td style="min-width:220px;font-weight:bold;"><a style="color:black;" href="{{ dayevent.project.get_absolute_url }}">{{ dayevent.project.job_name|truncatechars:48 }}</a> </td>
@@ -63,10 +63,10 @@
     {% endif %} 
     {% if querysettomorrow %}
       {% for dayevent in querysettomorrow %}
-        {% for workers in dayevent.workers.all %}
+        {% for artist in dayevent.artist.all %}
           <tr style="background-color:{{dayevent.color_event}};">
           <td style="min-width:68px;font-weight:bold;"><a style="color:black;font-weight:bold;" href="{{ dayevent.get_absolute_url }}">{{dayevent.start|date:"m/d"}}</a> </td>
-          <td style="min-width:80px;font-weight:bold;"><a style="color:black;font-weight:bold;" href="{{ workers.get_absolute_url }}">{{ workers.first_name }} {{ workers.last_name }}</a><br> </td>
+          <td style="min-width:80px;font-weight:bold;"><a style="color:black;font-weight:bold;" href="{{ artist.get_absolute_url }}">{{ artist.first_name }} {{ artist.last_name }}</a><br> </td>
           <td style="min-width:92px;font-weight:bold;"><a style="color:black;font-weight:bold;" href="{{ dayevent.get_absolute_url }}">{{ dayevent.start_time|date:"f A" }}</a> </td>
           <td style="min-width:92px;font-weight:bold;"><a style="color:black;font-weight:bold;" href="{{ dayevent.get_absolute_url }}">{{ dayevent.start|date:"f A" }}</a> </td>
           <td style="min-width:220px;font-weight:bold;"><a style="color:black;" href="{{ dayevent.project.get_absolute_url }}">{{ dayevent.project.job_name|truncatechars:48 }}</a> </td>


### PR DESCRIPTION
## Summary
- reference Event.artist instead of nonexistent workers field
- update project form templates
- rename worker loops to artist loops across schedule templates
- fix admin project copy logic

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686b3d3b0574833280aa21e4bfbbb4ca