### PR TITLE
Fix schedule urls

### DIFF
--- a/labmunkznetwork/urls.py
+++ b/labmunkznetwork/urls.py
@@ -26,7 +26,7 @@ urlpatterns = [
     path('project/', include('project.urls')),
     path('material/', include('material.urls')),
     path('posts/', include('posts.urls')),
-    path('schedule/', include('schedule.urls')),
+    path('schedule/', include('schedule.urls', namespace='schedule')),
     path('timecard/', include('timecard.urls')),
     path('todo/', include('todo.urls', namespace="todo")),
    # path('wip/', include('wip.urls')),

--- a/schedule/templates/fullcalendar.html
+++ b/schedule/templates/fullcalendar.html
@@ -18,7 +18,7 @@
                 {% endfor %}
             </ul>
         {% endif %}
-<a class="btn btn-primary gradient" href="{% url 'calendar_create_event' calendar_slug %}">
+<a class="btn btn-primary gradient" href="{% url 'schedule:calendar_create_event' calendar_slug %}">
     <span class='glyphicon glyphicon-plus'></span>
     {% trans "Add New Session" %}
 </a>

--- a/schedule/templates/fullcalendar_script.html
+++ b/schedule/templates/fullcalendar_script.html
@@ -20,7 +20,7 @@ $(document).ready(function() {
     function getEventViewURL(event){
         if (event.existed){
             if("{{ request.get_full_path }}".indexOf("/admin") != 0){
-                var view_url = "{% url 'occurrence' 12345 6789 %}".replace(/12345/, event.event_id).replace(/6789/, event.id);
+                var view_url = "{% url 'schedule:occurrence' 12345 6789 %}".replace(/12345/, event.event_id).replace(/6789/, event.id);
             }
             else{
                 var view_url = "{% url 'admin:schedule_occurrence_change' 12345 %}".replace(/12345/, event.id)
@@ -28,7 +28,7 @@ $(document).ready(function() {
         }
         else {
             if("{{ request.get_full_path }}".indexOf("/admin") != 0){
-                var view_url = "{% url 'event' 12345 %}".replace(/12345/, event.event_id);
+                var view_url = "{% url 'schedule:event' 12345 %}".replace(/12345/, event.event_id);
             }
             else{
                 var view_url = "{% url 'admin:schedule_event_change' 12345 %}".replace(/12345/, event.event_id)
@@ -40,12 +40,12 @@ $(document).ready(function() {
     function setModalProperties(type, event){
         if(type == 'edit'){
             var tYPE = '{% trans "Edit" %}';
-            var all_url = "{% url 'edit_event' calendar_slug 12345 %}".replace(/12345/, event.event_id);
+            var all_url = "{% url 'schedule:edit_event' calendar_slug 12345 %}".replace(/12345/, event.event_id);
             if (event.existed){
-                var this_url = "{% url 'edit_occurrence' 12345 6789 %}".replace(/12345/, event.event_id).replace(/6789/, event.id);
+                var this_url = "{% url 'schedule:edit_occurrence' 12345 6789 %}".replace(/12345/, event.event_id).replace(/6789/, event.id);
             }
             else{
-                var this_url = "{% url 'edit_occurrence_by_date' 123 234 345 456 567 678 789 %}".replace(
+                var this_url = "{% url 'schedule:edit_occurrence_by_date' 123 234 345 456 567 678 789 %}".replace(
                         /123/, event.event_id).replace(
                         /234/, event.year).replace(
                         /345/, event.month).replace(
@@ -57,12 +57,12 @@ $(document).ready(function() {
         }
         else if(type == 'delete'){
             var tYPE = '{% trans "Delete" %}';
-            var all_url = "{% url 'delete_event' 12345 %}".replace(/12345/, event.event_id);
+            var all_url = "{% url 'schedule:delete_event' 12345 %}".replace(/12345/, event.event_id);
             if (event.existed){
-                var this_url = "{% url 'cancel_occurrence' 12345 6789 %}".replace(/12345/, event.event_id).replace(/6789/, event.id);
+                var this_url = "{% url 'schedule:cancel_occurrence' 12345 6789 %}".replace(/12345/, event.event_id).replace(/6789/, event.id);
             }
             else{
-                var this_url = "{% url 'cancel_occurrence_by_date' 123 234 345 456 567 678 789 %}".replace(
+                var this_url = "{% url 'schedule:cancel_occurrence_by_date' 123 234 345 456 567 678 789 %}".replace(
                         /123/, event.event_id).replace(
                         /234/, event.year).replace(
                         /345/, event.month).replace(
@@ -123,7 +123,7 @@ $(document).ready(function() {
         eventLimit: true, // allow 'more' link when too many events
         selectable: {% if request.user.staff %}true{% else %}false{% endif %}, //Allows a user to highlight multiple days or timeslots by clicking and dragging.
         selectHelper: {% if request.user.staff %}true{% else %}false{% endif %},
-        events: "{% url 'api_occurrences' %}?calendar_slug={{calendar_slug}}",
+        events: "{% url 'schedule:api_occurrences' %}?calendar_slug={{calendar_slug}}",
         loading: function(bool) {
             if (bool) {
                 $('#loading').show();
@@ -178,7 +178,7 @@ $(document).ready(function() {
         eventDrop: function(event,delta,revertFunc) {
             $.ajax({
                     type: 'POST',
-                    url: "{% url 'api_move_or_resize' %}",
+                    url: "{% url 'schedule:api_move_or_resize' %}",
                     dataType: 'json',
                     data : {
                         'id': event.id,
@@ -199,7 +199,7 @@ $(document).ready(function() {
         eventResize: function(event,delta,revertFunc) {
             $.ajax({
                     type: 'POST',
-                    url: "{% url 'api_move_or_resize' %}",
+                    url: "{% url 'schedule:api_move_or_resize' %}",
                     dataType: 'json',
                     data : {
                         'id': event.id,
@@ -223,7 +223,7 @@ $(document).ready(function() {
                 console.log('{{calendar_slug}}');
                 $.ajax({
                         type: 'POST',
-                        url: "{% url 'api_select_create' %}",
+                        url: "{% url 'schedule:api_select_create' %}",
                         dataType: 'json',
                         data : {
                             'start': start.toISOString(),

--- a/schedule/templates/profiles/schedule.html
+++ b/schedule/templates/profiles/schedule.html
@@ -29,14 +29,14 @@
             <td>{{ event.title }}</td>
             <td>
                 {% block schedule_event_controls %}
-                <a href="{% url "event" event.pk %}" title="{% trans "Event details" %} {{ event }}">
+                <a href="{% url "schedule:event" event.pk %}" title="{% trans "Event details" %} {{ event }}">
                     <img src="{{ settings.MEDIA_URL }}icons/time_go.png" alt="{% trans "Event details" %}">
                 </a>
                 {% ifequal request.user other_user %}
-                <a href="{% url "edit_event" calendar.slug event.pk %}" title="{% trans "Edit event" %} {{ event }}">
+                <a href="{% url "schedule:edit_event" calendar.slug event.pk %}" title="{% trans "Edit event" %} {{ event }}">
                     <img src="{{ settings.MEDIA_URL }}icons/time_edit.png" alt="{% trans "Edit event" %}">
                 </a>
-                <a href="{% url "delete_event" event.pk %}" title="{% trans "Delete event" %} {{ event }}">
+                <a href="{% url "schedule:delete_event" event.pk %}" title="{% trans "Delete event" %} {{ event }}">
                     <img src="{{ settings.MEDIA_URL }}icons/time_delete.png" alt="{% trans "Delete event" %}">
                 </a>
                 {% endifequal %}
@@ -47,12 +47,12 @@
     </tbody>
 </table>
 {% else %}
-    {% url "calendar_create_event" as add_event_url %}
+    {% url "schedule:calendar_create_event" as add_event_url %}
     <p>{% blocktrans %}You haven't added any <a href="{{ add_event_url }}">event</a> yet.{% endblocktrans %}</p>
 {% endif %}
 
 <p>
-    <a href="{% url "calendar_create_event" calendar %}">{% block schedule_add_event_link_label %}{% trans "Add event" %}{% endblock %}</a>
+    <a href="{% url "schedule:calendar_create_event" calendar %}">{% block schedule_add_event_link_label %}{% trans "Add event" %}{% endblock %}</a>
 </p>
 
 {% endblock %}

--- a/schedule/templates/schedule/calendar_month.html
+++ b/schedule/templates/schedule/calendar_month.html
@@ -3,7 +3,7 @@
 {% load scheduletags i18n %}
 
 {% block title %}<title>Calendar Month</title>{% endblock %}
-{% block breadcrumb %} / <a href="{% url 'calendar_list' %}">{{ calendar.name }}</a>{% endblock %}
+{% block breadcrumb %} / <a href="{% url 'schedule:calendar_list' %}">{{ calendar.name }}</a>{% endblock %}
 {% block styler %}  
   <link rel="stylesheet" href="{% static 'schedule/schedule.css' %}" type="text/css" media="screen">
   <link rel="stylesheet" href="{% static 'schedule/jquery-ui.css' %}" type="text/css" media="screen">

--- a/schedule/templates/schedule/create_event.html
+++ b/schedule/templates/schedule/create_event.html
@@ -3,7 +3,7 @@
 
 
 {% block title %}<title>Event Update</title> {% endblock %}
-{% block breadcrumb %} / <a href="{% url 'schedule' %}">Schedule</a> / Update Event info{% endblock %}
+{% block breadcrumb %} / <a href="{% url 'schedule:schedule' %}">Schedule</a> / Update Event info{% endblock %}
 
 {% block content %}
 {% if request.user.staff %}

--- a/schedule/templates/schedule/dayevent_detail.html
+++ b/schedule/templates/schedule/dayevent_detail.html
@@ -2,7 +2,7 @@
 
 {% block title %}<title>Day event details</title>{% endblock %}
 
-{% block breadcrumb %} / <a href="{% url 'schedule' %}">Schedule</a> / Day event detail{% endblock %}
+{% block breadcrumb %} / <a href="{% url 'schedule:schedule' %}">Schedule</a> / Day event detail{% endblock %}
 
  
 {% block content %}

--- a/schedule/templates/schedule/edit_occurrence.html
+++ b/schedule/templates/schedule/edit_occurrence.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 
 {% block title %}<title>Event Update</title> {% endblock %}
-{% block breadcrumb %} / <a href="{% url 'schedule' %}">Schedule</a> / Update Event info{% endblock %}
+{% block breadcrumb %} / <a href="{% url 'schedule:schedule' %}">Schedule</a> / Update Event info{% endblock %}
 
 {% block content %}
 {{ form.non_field_errors }}

--- a/schedule/templates/schedule/event.html
+++ b/schedule/templates/schedule/event.html
@@ -3,15 +3,15 @@
 
 {% block title %}<title>Day event details</title>{% endblock %}
 
-{% block breadcrumb %} / <a href="{% url 'schedule' %}">Schedule</a> / Day event detail{% endblock %}
+{% block breadcrumb %} / <a href="{% url 'schedule:schedule' %}">Schedule</a> / Day event detail{% endblock %}
 
 {% block content %}
 
     {% if request.user.staff %}
 <div class="row">
   <div class="col-lg-2">
-      <a href="{% url 'delete_event' event.id %}"> <i class="fa fa-trash"></i> delete </a> -
-      <a href="{% url 'edit_event' event.calendar.slug event.id  %}"><i class="fa fa-pencil"></i> edit</a>
+      <a href="{% url 'schedule:delete_event' event.id %}"> <i class="fa fa-trash"></i> delete </a> -
+      <a href="{% url 'schedule:edit_event' event.calendar.slug event.id  %}"><i class="fa fa-pencil"></i> edit</a>
   </div>
 </div>
     {% endif %}

--- a/schedule/templates/schedule/event_archive_day.html
+++ b/schedule/templates/schedule/event_archive_day.html
@@ -3,23 +3,23 @@
 {% load static %}
 {% block title %}<title>Schedule</title>{% endblock %}
 {% block styler %}<link href="{% static 'home/vendor/datatables/dataTables.bootstrap4.css' %}" rel="stylesheet" type="text/css"> {% endblock %}
-{% block breadcrumb %} / <a href="{% url 'schedule' %}">Schedule</a> / <b>{{ day }}</b>
-{% if request.user.staff %} / <a href="{% url 'create-event' proj=0 %}">add a new event</a>{% else %}{% endif %}
+{% block breadcrumb %} / <a href="{% url 'schedule:schedule' %}">Schedule</a> / <b>{{ day }}</b>
+{% if request.user.staff %} / <a href="{% url 'schedule:create-event' proj=0 %}">add a new event</a>{% else %}{% endif %}
 {% endblock %}
 
 {% block content %}
 <div class="row" style="margin: auto; width:300px;">
   {% if previous_day %}
-  <a style="margin: auto;font-size:large;color:black;font-weight:bold;" href="{% with year=previous_day.year month=previous_day|date:'b' day=previous_day.day %}{% url 'archive_day' year month day %}{% endwith %}">
+  <a style="margin: auto;font-size:large;color:black;font-weight:bold;" href="{% with year=previous_day.year month=previous_day|date:'b' day=previous_day.day %}{% url 'schedule:archive_day' year month day %}{% endwith %}">
   <div class="col-lg-12">
     <i class="fa fa-arrow-circle-left" aria-hidden="true"></i> {{ previous_day|date:'m/d' }}</div></a>
   {% endif %}
   {% if previous_day and next_day %}
-  <a style="margin: auto;font-size:large;color:black;font-weight:bold;" href="{% url 'archive_today' %}">
+  <a style="margin: auto;font-size:large;color:black;font-weight:bold;" href="{% url 'schedule:archive_today' %}">
   <div class="col-lg-12" style="text-align:center; border-style:groove; border-radius:8px;">Today</div></a>
   {% endif %}
   {% if next_day %}
-  <a style="margin: auto;font-size:large;color:black;font-weight:bold;" href="{% with year=next_day.year month=next_day|date:'b' day=next_day.day %}{% url 'archive_day' year month day %}{% endwith %}">
+  <a style="margin: auto;font-size:large;color:black;font-weight:bold;" href="{% with year=next_day.year month=next_day|date:'b' day=next_day.day %}{% url 'schedule:archive_day' year month day %}{% endwith %}">
   <div class="col-lg-12">{{ next_day|date:'m/d' }} <i class="fa fa-arrow-circle-right" aria-hidden="true"></i></div></a>
   {% endif %}
 </div>

--- a/schedule/templates/schedule/event_form.html
+++ b/schedule/templates/schedule/event_form.html
@@ -3,7 +3,7 @@
 
 
 {% block title %}<title>Event Update</title> {% endblock %}
-{% block breadcrumb %} / <a href="{% url 'schedule' %}">Schedule</a> / Update Event info{% endblock %}
+{% block breadcrumb %} / <a href="{% url 'schedule:schedule' %}">Schedule</a> / Update Event info{% endblock %}
 
 {% block content %}
 {% if request.user.staff %}

--- a/schedule/templates/schedule/schedule_day_list.html
+++ b/schedule/templates/schedule/schedule_day_list.html
@@ -2,7 +2,7 @@
 {% load static %}
 {% block title %}<title>Schedule</title>{% endblock %}
 {% block styler %}<link href="{% static 'home/vendor/datatables/dataTables.bootstrap4.css' %}" rel="stylesheet" type="text/css"> {% endblock %}
-{% block breadcrumb %} / <a href="{% url 'schedule' %}">Schedule</a> / <b>{{ now|date:"F, jS o" }}</b>{% if request.user.staff %} / <a href="{% url 'create-event' proj=dayevent.project.job_num %}">add a new event</a>
+{% block breadcrumb %} / <a href="{% url 'schedule:schedule' %}">Schedule</a> / <b>{{ now|date:"F, jS o" }}</b>{% if request.user.staff %} / <a href="{% url 'schedule:create-event' proj=dayevent.project.job_num %}">add a new event</a>
 {% else %}
 {% endif %}
 {% endblock %}

--- a/schedule/templatetags/scheduletags.py
+++ b/schedule/templatetags/scheduletags.py
@@ -89,8 +89,8 @@ def options(context, occurrence):
     if CHECK_EVENT_PERM_FUNC(occurrence.event, user) and CHECK_CALENDAR_PERM_FUNC(occurrence.event.calendar, user):
         context['edit_occurrence'] = occurrence.get_edit_url()
         context['cancel_occurrence'] = occurrence.get_cancel_url()
-        context['delete_event'] = reverse('delete_event', args=(occurrence.event.id,))
-        context['edit_event'] = reverse('edit_event', args=(occurrence.event.calendar.slug, occurrence.event.id,))
+        context['delete_event'] = reverse('schedule:delete_event', args=(occurrence.event.id,))
+        context['edit_event'] = reverse('schedule:edit_event', args=(occurrence.event.calendar.slug, occurrence.event.id,))
     else:
         context['edit_event'] = context['delete_event'] = ''
     return context
@@ -106,7 +106,7 @@ def create_event_url(context, calendar, slot):
         'calendar_slug': calendar.slug,
     }
     context['create_event_url'] = '%s%s' % (
-        reverse('calendar_create_event', kwargs=lookup_context),
+        reverse('schedule:calendar_create_event', kwargs=lookup_context),
         querystring_for_date(slot))
     return context
 


### PR DESCRIPTION
## Summary
- add namespace when including schedule URLs
- prefix schedule URLs in templates
- update schedule template tag

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686b3f9213948332901c8772ec049fb7