### PR TITLE
Fix schedule occurrence URL reversing

### DIFF
--- a/schedule/models/events.py
+++ b/schedule/models/events.py
@@ -632,9 +632,9 @@ class Occurrence(models.Model):
 
     def get_absolute_url(self):
         if self.pk is not None:
-            return reverse('occurrence', kwargs={'occurrence_id': self.pk,
+            return reverse('schedule:occurrence', kwargs={'occurrence_id': self.pk,
                                                  'event_id': self.event.id})
-        return reverse('occurrence_by_date', kwargs={
+        return reverse('schedule:occurrence_by_date', kwargs={
             'event_id': self.event.id,
             'year': self.start.year,
             'month': self.start.month,
@@ -646,9 +646,9 @@ class Occurrence(models.Model):
 
     def get_cancel_url(self):
         if self.pk is not None:
-            return reverse('cancel_occurrence', kwargs={'occurrence_id': self.pk,
+            return reverse('schedule:cancel_occurrence', kwargs={'occurrence_id': self.pk,
                                                         'event_id': self.event.id})
-        return reverse('cancel_occurrence_by_date', kwargs={
+        return reverse('schedule:cancel_occurrence_by_date', kwargs={
             'event_id': self.event.id,
             'year': self.start.year,
             'month': self.start.month,
@@ -660,9 +660,9 @@ class Occurrence(models.Model):
 
     def get_edit_url(self):
         if self.pk is not None:
-            return reverse('edit_occurrence', kwargs={'occurrence_id': self.pk,
+            return reverse('schedule:edit_occurrence', kwargs={'occurrence_id': self.pk,
                                                       'event_id': self.event.id})
-        return reverse('edit_occurrence_by_date', kwargs={
+        return reverse('schedule:edit_occurrence_by_date', kwargs={
             'event_id': self.event.id,
             'year': self.start.year,
             'month': self.start.month,


### PR DESCRIPTION
## Summary
- fix mismatched URL names for `Occurrence` model methods

## Testing
- `python manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_686b427455488332bd142b6003c3bd94