### PR TITLE
Update requirements for additional packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # hiphopculture.org
 Social Media
+
+## Installation
+
+Install system packages needed for building some Python dependencies:
+
+```bash
+sudo apt-get install python3-dev libjpeg-dev libpng-dev zlib1g-dev
+```
+
+Then install project requirements:
+
+```bash
+pip install -r requirements.txt
+```
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,12 @@
 Django==3.2.25
 django-environ
 psycopg2-binary
-Pillow
+Pillow>=10.0.0
 Faker
 titlecase
 factory-boy
-wheel
+wheel>=0.42.0
 python-dateutil
+librosa
+mutagen
+bleach


### PR DESCRIPTION
## Summary
- add librosa, mutagen, and bleach to requirements

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_686b536896d0833286870713f0cd2f59