### PR TITLE
Adjust group detail layout for wider screens

### DIFF
--- a/group/templates/group_detail.html
+++ b/group/templates/group_detail.html
@@ -47,6 +47,7 @@
             <p class="group-summary">{{ group_detail.summary }}</p>
         </div>
 
+        <div class="details-grid">
         <!-- Albums -->
         <div id="albums" class="tab-content">
             <div class="business-card">
@@ -191,6 +192,7 @@
                 </tbody>
             </table>
         </div>
+        </div><!-- end details-grid -->
 
         <!-- Contact Info -->
         <div class="group-contact">

--- a/static/group/css/group_detail.css
+++ b/static/group/css/group_detail.css
@@ -119,3 +119,18 @@
 .tour-table tr:nth-child(even) {
     background-color: #f2f2f2;
 }
+
+/* Layout for large screens */
+.details-grid {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
+@media screen and (min-width: 992px) {
+    .details-grid {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 20px;
+    }
+}


### PR DESCRIPTION
## Summary
- add responsive `details-grid` on group detail page
- arrange album, member, and event sections into columns on large screens

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686b5929657c8332a4e89c6562283810