### PR TITLE
Fix mobile layout overflow on music and group pages

### DIFF
--- a/static/home/css/styles.css
+++ b/static/home/css/styles.css
@@ -4,6 +4,10 @@
     font-weight: normal;
     font-style: normal;
 }
+/* Ensure padding doesn't cause horizontal overflow */
+*, *::before, *::after {
+    box-sizing: border-box;
+}
 .icon-bar {
     position: fixed;
     bottom: 0%;
@@ -431,7 +435,7 @@ main {
     justify-content: space-between;
     padding-left: 0px;
     padding-right: 0px;
-    width: 111%;
+    width: 100%;
 }
 
 .song-list-left {


### PR DESCRIPTION
## Summary
- add universal box-sizing rule so padding doesn't create overflow
- correct song list width on the music page

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686b5fbba7888332afb47b6646d3c8b5