### PR TITLE
Restore group logo banner

### DIFF
--- a/group/templates/group_detail.html
+++ b/group/templates/group_detail.html
@@ -12,6 +12,11 @@
 {% block breadcrumb %} / <a href="{% url 'group:group' %}">Groups</a> / {{ group_detail.group_name }}{% endblock %}
 
 {% block content %}
+<header class="header"
+    {% if group_detail.logo %}
+        style="background: url('{{ group_detail.logo.url }}') no-repeat center center; background-size: cover;"
+    {% endif %}>
+</header>
 <div class="container">
     <div class="card">
         <!-- Group Banner -->

--- a/static/group/css/group_detail.css
+++ b/static/group/css/group_detail.css
@@ -1,3 +1,10 @@
+body {
+    font-family: 'LabFont', sans-serif;
+    margin: 0;
+    padding: 0;
+    background: url('/static/home/css/tile23.jpg');
+}
+
 /* Profile Banner */
 .profile-banner {
     width: 100%;


### PR DESCRIPTION
## Summary
- show group logo as the banner image on group pages
- add body styling and background image in group detail CSS

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686b6d4729608332b67daa7c76d68f08