### PR TITLE
Fix group detail asset placement and CSS

### DIFF
--- a/group/templates/group_detail.html
+++ b/group/templates/group_detail.html
@@ -9,22 +9,28 @@
 <meta name="description" content="{{ group_detail.summary|default:'Group information' }}">
 {% endblock %}
 
+{% block body_attrs %}
+    {% if group_detail.background_image %}
+        style="background: url('{{ group_detail.background_image.url }}')"
+    {% endif %}
+{% endblock %}
+
 {% block breadcrumb %} / <a href="{% url 'group:group' %}">Groups</a> / {{ group_detail.group_name }}{% endblock %}
 
 {% block content %}
 <header class="header"
-    {% if group_detail.logo %}
-        style="background: url('{{ group_detail.logo.url }}') no-repeat center center; background-size: cover;"
+    {% if group_detail.background_image %}
+        style="background: url('{{ group_detail.background_image.url }}') no-repeat center center; background-size: cover;"
     {% endif %}>
 </header>
 <div class="container">
     <div class="card">
         <!-- Group Banner -->
-        <div class="profile-banner" 
-            {% if group_detail.background_image %}
-                style="background-image: url('{{ group_detail.background_image.url }}');"
-            {% elif group_detail.logo %}
+        <div class="profile-banner"
+            {% if group_detail.logo %}
                 style="background-image: url('{{ group_detail.logo.url }}');"
+            {% elif group_detail.background_image %}
+                style="background-image: url('{{ group_detail.background_image.url }}');"
             {% endif %}>
             <div class="profile-pic-container">
                 {% if group_detail.button %}

--- a/home/templates/home/base.html
+++ b/home/templates/home/base.html
@@ -23,7 +23,7 @@
      {% block extra_css %}{% endblock %}
 
 </head>
-<body>     
+<body{% block body_attrs %}{% endblock %}>
     {% include 'home/navbar.html' %}
     {% if messages %}
     <div class="messages">

--- a/static/group/css/group_detail.css
+++ b/static/group/css/group_detail.css
@@ -1,10 +1,3 @@
-body {
-    font-family: 'LabFont', sans-serif;
-    margin: 0;
-    padding: 0;
-    background: url('/static/home/css/tile23.jpg');
-}
-
 /* Profile Banner */
 .profile-banner {
     width: 100%;


### PR DESCRIPTION
## Summary
- add body attribute block in base template
- use group background image for page header and page body
- show group logo as profile banner
- drop duplicate body styling from group_detail.css

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686b6f7eef78833295913f0f7ff9ee67